### PR TITLE
Travis CI speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
     - 2.7
     - 3.4
 
+sudo: false
+
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Use container-based infrastructure. Travis CI says:

> Jobs running on container-based infrastructure:

> * start up faster
> * allow the use of caches for public repositories
> * disallow the use of sudo, setuid and setgid executables

http://docs.travis-ci.com/user/workers/container-based-infrastructure/