### PR TITLE
Project-specific error report page

### DIFF
--- a/terroroftinytown/tracker/admin.py
+++ b/terroroftinytown/tracker/admin.py
@@ -66,8 +66,10 @@ class BannedHandler(BaseHandler):
 class ErrorReportsListHandler(BaseHandler):
     @tornado.web.authenticated
     def get(self):
-        offset_id = int(self.get_argument('offset_id', 0))
-        error_reports = ErrorReport.all_reports(offset_id=offset_id)
+        project_id=self.get_argument('project_id', None)
+        error_reports = ErrorReport.all_reports(
+            offset_id=int(self.get_argument('offset_id', 0)),
+            project_id=project_id)
         auto_delete_form = AutoDeleteErrorReportsForm(
             enabled=GlobalSetting.get_value(
                 GlobalSetting.AUTO_DELETE_ERROR_REPORTS)
@@ -79,7 +81,8 @@ class ErrorReportsListHandler(BaseHandler):
             delete_all_form=DeleteAllErrorReportsForm(),
             auto_delete_form=auto_delete_form,
             next_offset_id=error_reports[-1]['id'] if error_reports else 0,
-            count=ErrorReport.get_count()
+            project_id=project_id,
+            count=ErrorReport.get_count() if project_id is None else 0
         )
 
 

--- a/terroroftinytown/tracker/model.py
+++ b/terroroftinytown/tracker/model.py
@@ -518,12 +518,15 @@ class ErrorReport(Base):
             return max_id - min_id
 
     @classmethod
-    def all_reports(cls, limit=100, offset_id=None):
+    def all_reports(cls, limit=100, offset_id=None, project_id=None):
         with new_session() as session:
             reports = session.query(ErrorReport)
 
             if offset_id:
                 reports = reports.filter(ErrorReport.id > offset_id)
+
+            if project_id is not None and project_id != 'None':
+                reports = reports.join(Item).filter(Item.project_id == project_id)
 
             reports = reports.limit(limit)
 

--- a/terroroftinytown/tracker/template/admin/overview/error_reports.html
+++ b/terroroftinytown/tracker/template/admin/overview/error_reports.html
@@ -4,15 +4,15 @@
 
 {% block main %}
 
-<h1>Error Reports</h1>
+<h1>Error Reports{{ ' for "{}" '.format(project_id) if project_id is not None else '' }}</h1>
 
 {% module Form(auto_delete_form, action=reverse_url('admin.error_reports.auto_delete_setting'), submit='Apply') %}
 
 <hr>
 
-<p>About {{ count }} reports exist.</p>
+<p>{{ 'There are about {:,} error reports total.'.format(count) if project_id is None else ''}}</p>
 
-<a class="btn btn-default" href="{{ '{}?offset_id={}'.format(reverse_url('admin.error_reports'), next_offset_id) }}">Show more</a>
+<a class="btn btn-default" href="{{ '{}?offset_id={}&project_id={}'.format(reverse_url('admin.error_reports'), next_offset_id, project_id) }}">Show more</a>
 
 <table class="table table-bordered table-striped">
 	<thead>
@@ -36,7 +36,7 @@
 	{% end %}
 </table>
 
-<a class="btn btn-default" href="{{ '{}?offset_id={}'.format(reverse_url('admin.error_reports'), next_offset_id) }}">Show more</a>
+<a class="btn btn-default" href="{{ '{}?offset_id={}&project_id={}'.format(reverse_url('admin.error_reports'), next_offset_id, project_id) }}">Show more</a>
 
 <hr>
 

--- a/terroroftinytown/tracker/template/admin/project/base.html
+++ b/terroroftinytown/tracker/template/admin/project/base.html
@@ -25,6 +25,9 @@
 			<a href="{{ reverse_url('admin.results')+'?limit=10&project_id='+project_name }}">Results</a>
 		</li>
 		<li class="list-group-item">
+			<a href="{{ reverse_url('admin.error_reports')+'?project_id='+project_name }}">Error Reports</a>
+		</li>
+		<li class="list-group-item">
 			<a href="{{ reverse_url('project.delete', project_name) }}">Delete</a>
 		</li>
 	</ul>


### PR DESCRIPTION
Makes it easier to see if a new project is generating any errors, without it getting swamped by other projects.