### PR TITLE
Add an index to results on project_id.

### DIFF
--- a/terroroftinytown/tracker/model.py
+++ b/terroroftinytown/tracker/model.py
@@ -431,7 +431,7 @@ class Result(Base):
 
     id = Column(Integer, primary_key=True)
 
-    project_id = Column(Integer, ForeignKey('projects.name'), nullable=False)
+    project_id = Column(Integer, ForeignKey('projects.name'), nullable=False, index=True)
     project = relationship('Project')
 
     shortcode = Column(String, nullable=False)


### PR DESCRIPTION
This stops the system from freaking out when you load results for a project that has none.