### PR TITLE
Add per-user stats api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3-alpine
+WORKDIR /usr/src
+COPY requirements-tracker.txt .
+RUN pip3 install -r requirements-tracker.txt
+COPY . .
+ENTRYPOINT ["python3", "-m", "terroroftinytown.tracker", "tracker_docker.conf"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: '3'
+services:
+  tracker:
+    build: .
+    ports:
+    - "8888:8888"
+    environment:
+    - PYTHONIOENCODING=utf-8
+  redis:
+    image: redis:alpine

--- a/terroroftinytown/tracker/api.py
+++ b/terroroftinytown/tracker/api.py
@@ -48,6 +48,12 @@ class LiveStatsHandler(tornado.websocket.WebSocketHandler):
         stats_bus.clear_handlers(self)
 
 
+class UserStatsHandler(BaseHandler):
+    def get(self, username):
+        stats = Stats.instance.get_user_lifetime(username)
+        self.write({'stats': stats})
+
+
 class GetHandler(BaseHandler):
     def post(self):
         ip_address = self.request.remote_ip

--- a/terroroftinytown/tracker/app.py
+++ b/terroroftinytown/tracker/app.py
@@ -49,6 +49,7 @@ class Application(tornado.web.Application):
             U(r'/project/([a-z0-9_-]*)/settings', project.SettingsHandler, name='project.settings'),
             U(r'/project/([a-z0-9_-]*)/delete', project.DeleteHandler, name='project.delete'),
             U(r'/api/live_stats', api.LiveStatsHandler, name='api.live_stats'),
+            U(r'/api/stats/([a-z0-9_-]+)', api.UserStatsHandler, name='api.user_stats'),
             U(r'/api/project_settings', api.ProjectSettingsHandler, name='api.project_settings'),
             U(r'/api/get', api.GetHandler, name='api.get'),
             U(r'/api/done', api.DoneHandler, name='api.done'),

--- a/terroroftinytown/tracker/stats.py
+++ b/terroroftinytown/tracker/stats.py
@@ -61,6 +61,13 @@ class Stats:
 
         return out
 
+    def get_user_lifetime(self, user):
+        '''Return user lifetime stats as array of [found, scanned]'''
+        key = self.get_key()
+        scanned = self.redis.hget(key+':s', user) or 0
+        found = self.redis.hget(key+':f', user) or 0
+        return [int(found), int(scanned)]
+
     def get_global(self):
         '''Return total stats as array of [found, scanned]'''
         found = self.redis.get(self.get_key()+':tf')

--- a/tracker_docker.conf
+++ b/tracker_docker.conf
@@ -1,0 +1,33 @@
+[web]
+host: 0.0.0.0
+port: 8888
+cookie_secret: EXAMPLE-a-long-string-here
+xheaders: false
+maintenance_sentinel_file: SUPERVISOR_EXPORT_PATH_HERE/tinytown-supervisor-sentinel
+
+[database]
+path: sqlite:///EXAMPLE.db
+
+[redis]
+host: redis
+port: 6379
+password: 
+db: 0
+unix: 
+prefix: tott:
+max_stats: 30
+
+[logging]
+path: ./EXAMPLE.log
+
+[iaexporter]
+access_key: 
+secret_key: 
+endpoint: s3.us.archive.org
+collection: test_collection
+format: beacon
+last_export_file: last_export.txt
+item: urlteam_{timestamp}
+timestamp: {year:04d}-{month:02d}-{day:02d}-{hour:02d}-{minute:02d}-{second:02d}
+title: URLTeam Release {timestamp} TEST TEST TEST
+description: URLTeam's rolling release of unshortened URLs.


### PR DESCRIPTION
This allows me to export statistics about a user without consuming the websocket stream.

Also includes a very simple docker development setup that I've used to test this.